### PR TITLE
Fix kc buoy research time variable

### DIFF
--- a/datasets/HakaiKCBuoyResearch.xml
+++ b/datasets/HakaiKCBuoyResearch.xml
@@ -3,17 +3,17 @@
 	<reloadEveryNMinutes>10080</reloadEveryNMinutes>
 	<updateEveryNMillis>10000</updateEveryNMillis>
 	<fileDir>/datasets/HakaiKCBuoyResearch/</fileDir>
-	<fileNameRegex>.*\.csv</fileNameRegex>
+	<fileNameRegex>.*transformed\.csv</fileNameRegex>
 	<recursive>false</recursive>
 	<pathRegex>.*</pathRegex>
 	<metadataFrom>last</metadataFrom>
 	<standardizeWhat>0</standardizeWhat>
 	<charset>UTF-8</charset>
 	<columnSeparator>,</columnSeparator>
-	<columnNamesRow>7</columnNamesRow>
-	<firstDataRow>8</firstDataRow>
-	<sortedColumnSourceName>Date</sortedColumnSourceName>
-	<sortFilesBySourceNames>Date</sortFilesBySourceNames>
+	<columnNamesRow>1</columnNamesRow>
+	<firstDataRow>2</firstDataRow>
+	<sortedColumnSourceName>time</sortedColumnSourceName>
+	<sortFilesBySourceNames>time</sortFilesBySourceNames>
 	<fileTableInMemory>false</fileTableInMemory>
 	<accessibleViaFiles>true</accessibleViaFiles>
 	<!-- sourceAttributes>
@@ -91,33 +91,7 @@
 		</addAttributes>
 	</dataVariable>
 	<dataVariable>
-		<sourceName>Date</sourceName>
-		<destinationName>Date</destinationName>
-		<dataType>String</dataType>
-		<!-- sourceAttributes>
-		</sourceAttributes -->
-		<addAttributes>
-			<att name="long_name">Date</att>
-			<att name="source_name">Date</att>
-			<att name="time_precision">1970-01-01</att>
-			<att name="units">yyyy-MM-dd</att>
-		</addAttributes>
-	</dataVariable>
-	<dataVariable>
-		<sourceName>Time UTC</sourceName>
-		<destinationName>TimeOfDay</destinationName>
-		<dataType>String</dataType>
-		<!-- sourceAttributes>
-		</sourceAttributes -->
-		<addAttributes>
-			<att name="long_name">Time of the day</att>
-			<att name="units">H:m</att>
-			<att name="timezone">'UTC'</att>
-		</addAttributes>
-	</dataVariable>
-	<dataVariable>
-		<sourceName>=Calendar2.parseToEpochSeconds(row.columnString("Date") + "T" + 
-			row.columnString("Time UTC") + "Z", "M/d/yyyy'T'H:m'Z'")</sourceName>
+		<sourceName>time</sourceName>
 		<destinationName>time</destinationName>
 		<dataType>String</dataType>
 		<!-- sourceAttributes>
@@ -125,7 +99,7 @@
 		<addAttributes>
 			<att name="long_name">Date Time</att>
 			<att name="standard_name">time</att>
-			<att name="units">seconds since 1970-01-01T00:00:00Z</att>
+			<att name="units">yyyy-MM-dd H:m:s</att>
 		</addAttributes>
 	</dataVariable>
 	<dataVariable>

--- a/scripts/HakaiKCBuoyResearch/add_kc_time_variables.py
+++ b/scripts/HakaiKCBuoyResearch/add_kc_time_variables.py
@@ -1,0 +1,27 @@
+import pandas as pd
+import argparse
+
+
+def convert_kc_buoy(input_path, output_path=None):
+    
+    if output_path is None:
+        output_path = input_path[:-2] +'_transformed.csv'
+
+    df = pd.read_csv(input_path, skiprows=6)
+
+    df['time'] = pd.to_datetime(df['Date'] + ' ' + df['Time UTC'])
+
+    df.to_csv(input_path[:-4] +'_transformed.csv')
+
+
+if __name__ == "__main__":
+
+    # parser = argparse.ArgumentParser(prog='add_kc_time_variable',
+    #                                  description="OA CSV format has time and date seperated this just regroup them into a time variable.")
+    # parser.add_argument(
+    #     '-i', type=str, dest="input_file_csv",
+    #     help="CSV file to convert")
+    #
+    # args = parser.parse_args()
+    # convert_kc_buoy(args.input_file_csv)
+    convert_kc_buoy(r"C:\Users\jessy\Documents\repositories\erddap-basic\datasets\HakaiKCBuoyResearch\187F20180501_May2018_Oct2020.csv")


### PR DESCRIPTION
Time variable was initially set by merging the Date and TimeOfDay variables. Since Hakai is runnin ERDDAP 2.02. Such method can be done within dataset.xml. We instead generated a transformed file.
Missing few changes

