### PR TITLE
Add 2um filter size to Chlorophyll view

### DIFF
--- a/datasets/HakaiChlorophyllSampleResearch.xml
+++ b/datasets/HakaiChlorophyllSampleResearch.xml
@@ -1,0 +1,285 @@
+<dataset type="EDDTableFromDatabase" datasetID="HakaiChlorophyllSampleResearch" active="true">
+    <sourceUrl>hakai_erddap_sourceUrl</sourceUrl>
+    <driverName>org.postgresql.Driver</driverName>
+    <schemaName>erddap</schemaName>
+    <tableName>"HakaiChlorophyllSampleResearch"</tableName>
+    <reloadEveryNMinutes>10080</reloadEveryNMinutes>
+    <!-- sourceAttributes>
+    </sourceAttributes -->
+    <!-- Please specify the actual cdm_data_type (TimeSeries?) and related info below, for example...
+        <att name="cdm_timeseries_variables">station_id, longitude, latitude</att>
+        <att name="subsetVariables">station_id, longitude, latitude</att>
+    -->
+    <addAttributes>
+        <att name="Conventions">COARDS, CF-1.6, ACDD-1.3</att>
+        <att name="infoUrl">hakai.org</att>
+        <att name="institution">Hakai Institute</att>
+        <att name="keywords">20um, 3um, area, bulk, chemistry, chla_20um, chla_3um, chla_bulk_gf_f, chla_gf_f, chlorophyll, collected, concentration, concentration_of_chlorophyll_in_sea_water, data, depth, earth, Earth Science &gt; Oceans &gt; Ocean Chemistry &gt; Chlorophyll, gather, gather_lat, gather_long, latitude, line, line_out_depth, local, long, longitude, ocean, oceans, organization, out, phaeo, phaeo_20um, phaeo_3um, phaeo_bulk_gf_f, phaeo_gf_f, pressure, pressure_transducer_depth, science, sea, seawater, site, site_id, source, survey, time, transducer, water, work, work_area</att>
+        <att name="keywords_vocabulary">GCMD Science Keywords</att>
+        <att name="license">[standard]</att>
+        <att name="sourceUrl">(local database)</att>
+        <att name="standard_name_vocabulary">CF Standard Name Table v55</att>
+        <att name="summary">This dataset is comprised of Hakai Institute chlorophyll and phaeopigment concentrations collected from 2017 to present at stations within the Calvert Island, Johnstone Strait, and the Quadra Island study regions. Samples for these data were collected in the field using Niskin bottles. Sample water (250 ml) was filtered through: 1) a single glass fiber filter (GF/F, nominal pore size 0.7 um) to comprise a bulk measure of phytoplankton chlorophyll and phaeopigment concentrations and 2) a stack of filters (GF/F, 3 um, and 20 um polycarbonate filters) to estimate chlorophyll and phaeopigment concentrations from pico, nano, and micro-phytoplankton, respectively. Filters were extracted for 24 hours in 10 ml of 90% acetone and analyzed on Turner Designs Trilogy laboratory fluorometers using the acidification module and following the method of Holm Hansen et al. (1965). Data have been quality controlled by manual inspection which included a comparison of bulk concentrations against the sum of the size-fractionated filter concentrations. Where available, further comparisons were done with other measures of chlorophyll concentrations including in situ CTD chlorophyll fluorescence and high-performance liquid chromatography (HPLC) data. Data were collected by the Hakai Institute Oceanography and Nearshore programs.</att>
+        <att name="title">Hakai Bulk and Size-Fractionated Chlorophyll and Phaeopigment Concentrations Collected by Niskin Bottle</att>
+        <att name="cdm_data_type">TimeSeriesProfile</att>
+        <att name="cdm_profile_variables">preciseLat, preciseLon, time </att>
+        <att name="cdm_timeseries_variables">latitude, longitude, site_id, work_area </att>
+        <att name="subsetVariables">work_area, survey, site_id, line_out_depth</att>
+    </addAttributes>
+    <dataVariable>
+        <sourceName>work_area</sourceName>
+        <destinationName>work_area</destinationName>
+        <dataType>String</dataType>
+        <!-- sourceAttributes>
+        </sourceAttributes -->
+        <addAttributes>
+            <att name="long_name">Work Area</att>
+        </addAttributes>
+    </dataVariable>
+    <dataVariable>
+        <sourceName>survey</sourceName>
+        <destinationName>survey</destinationName>
+        <dataType>String</dataType>
+        <!-- sourceAttributes>
+        </sourceAttributes -->
+        <addAttributes>
+            <att name="long_name">Survey</att>
+        </addAttributes>
+    </dataVariable>
+    <dataVariable>
+        <sourceName>site_id</sourceName>
+        <destinationName>site_id</destinationName>
+        <dataType>String</dataType>
+        <!-- sourceAttributes>
+        </sourceAttributes -->
+        <addAttributes>
+            <att name="long_name">Site Id</att>
+            <att name="cf_role">timeseries_id</att>
+        </addAttributes>
+    </dataVariable>
+    <dataVariable>
+        <sourceName>lat</sourceName>
+        <destinationName>latitude</destinationName>
+        <dataType>double</dataType>
+        <!-- sourceAttributes>
+        </sourceAttributes -->
+        <addAttributes>
+            <att name="colorBarMaximum" type="double">90.0</att>
+            <att name="colorBarMinimum" type="double">-90.0</att>
+            <att name="long_name">Latitude</att>
+            <att name="standard_name">latitude</att>
+            <att name="units">degrees_north</att>
+        </addAttributes>
+    </dataVariable>
+    <dataVariable>
+        <sourceName>long</sourceName>
+        <destinationName>longitude</destinationName>
+        <dataType>double</dataType>
+        <!-- sourceAttributes>
+        </sourceAttributes -->
+        <addAttributes>
+            <att name="colorBarMaximum" type="double">180.0</att>
+            <att name="colorBarMinimum" type="double">-180.0</att>
+            <att name="long_name">Longitude</att>
+            <att name="source_name">long</att>
+            <att name="standard_name">longitude</att>
+            <att name="units">degrees_east</att>
+        </addAttributes>
+    </dataVariable>
+    <dataVariable>
+        <sourceName>gather_lat</sourceName>
+        <destinationName>preciseLat</destinationName>
+        <dataType>double</dataType>
+        <!-- sourceAttributes>
+        </sourceAttributes -->
+        <addAttributes>
+            <att name="long_name">Precise Latitude</att>
+            <att name="units">degrees_north</att>
+        </addAttributes>
+    </dataVariable>
+    <dataVariable>
+        <sourceName>gather_long</sourceName>
+        <destinationName>preciseLon</destinationName>
+        <dataType>double</dataType>
+        <!-- sourceAttributes>
+        </sourceAttributes -->
+        <addAttributes>
+            <att name="long_name">Precise Longitude</att>
+            <att name="units">degrees_east</att>
+        </addAttributes>
+    </dataVariable>
+    <dataVariable>
+        <sourceName>=line_out_depth</sourceName>
+        <destinationName>depth</destinationName>
+        <dataType>double</dataType>
+        <!-- sourceAttributes>
+        </sourceAttributes -->
+        <addAttributes>
+            <att name="long_name">Depth</att>
+            <att name="units">m</att>
+        </addAttributes>
+    </dataVariable>
+    <dataVariable>
+        <sourceName>line_out_depth</sourceName>
+        <destinationName>line_out_depth</destinationName>
+        <dataType>double</dataType>
+        <!-- sourceAttributes>
+        </sourceAttributes -->
+        <addAttributes>
+            <att name="long_name">Line Out Depth</att>
+            <att name="units">m</att>
+        </addAttributes>
+    </dataVariable>
+    <dataVariable>
+        <sourceName>pressure_transducer_depth</sourceName>
+        <destinationName>pressure_transducer_depth</destinationName>
+        <dataType>double</dataType>
+        <!-- sourceAttributes>
+        </sourceAttributes -->
+        <addAttributes>
+            <att name="long_name">Pressure Transducer Depth</att>
+            <att name="units">m</att>
+        </addAttributes>
+    </dataVariable>
+    <dataVariable>
+        <sourceName>collected</sourceName>
+        <destinationName>time</destinationName>
+        <dataType>double</dataType>
+        <!-- sourceAttributes>
+        </sourceAttributes -->
+        <addAttributes>
+            <att name="cf_role">profile_id</att>
+            <att name="ioos_category">Time</att>
+            <att name="long_name">Collected</att>
+            <att name="source_name">collected</att>
+            <att name="standard_name">time</att>
+            <att name="units">seconds since 1970-01-01T00:00:00Z</att>
+        </addAttributes>
+    </dataVariable>
+    <dataVariable>
+        <sourceName>phaeo_20um</sourceName>
+        <destinationName>phaeo_20um</destinationName>
+        <dataType>double</dataType>
+        <!-- sourceAttributes>
+        </sourceAttributes -->
+        <addAttributes>
+            <att name="long_name">Phaeo 20um</att>
+            <att name="long_name">Bigger than 20um Concentration Of Phaeopigments In Sea Water</att>
+            <att name="units">ug/L</att>
+        </addAttributes>
+    </dataVariable>
+    <dataVariable>
+        <sourceName>phaeo_3um</sourceName>
+        <destinationName>phaeo_3um</destinationName>
+        <dataType>double</dataType>
+        <!-- sourceAttributes>
+        </sourceAttributes -->
+        <addAttributes>
+            <att name="long_name">3um to 20um Concentration Of Phaeopigments In Sea Water</att>
+            <att name="units">ug/L</att>
+        </addAttributes>
+    </dataVariable>
+    <dataVariable>
+        <sourceName>phaeo_2um</sourceName>
+        <destinationName>phaeo_2um</destinationName>
+        <dataType>double</dataType>
+        <!-- sourceAttributes>
+        </sourceAttributes -->
+        <addAttributes>
+            <att name="long_name">2um to 20um Concentration Of Phaeopigments In Sea Water</att>
+            <att name="units">ug/L</att>
+        </addAttributes>
+    </dataVariable>
+    <dataVariable>
+        <sourceName>phaeo_gf_f</sourceName>
+        <destinationName>phaeo_gf_f</destinationName>
+        <dataType>double</dataType>
+        <!-- sourceAttributes>
+        </sourceAttributes -->
+        <addAttributes>
+            <att name="long_name">Smaller than 2um Concentration Of Phaeopigments In Sea Water</att>
+            <att name="units">ug/L</att>
+        </addAttributes>
+    </dataVariable>
+    <dataVariable>
+        <sourceName>phaeo_bulk_gf_f</sourceName>
+        <destinationName>phaeo_bulk_gf_f</destinationName>
+        <dataType>double</dataType>
+        <!-- sourceAttributes>
+        </sourceAttributes -->
+        <addAttributes>
+            <att name="long_name">Bulk Concentration Of Phaeopigments In Sea Water</att>
+            <att name="units">ug/L</att>
+        </addAttributes>
+    </dataVariable>
+    <dataVariable>
+        <sourceName>chla_20um</sourceName>
+        <destinationName>chla_20um</destinationName>
+        <dataType>double</dataType>
+        <!-- sourceAttributes>
+        </sourceAttributes -->
+        <addAttributes>
+            <att name="colorBarMaximum" type="double">30.0</att>
+            <att name="colorBarMinimum" type="double">0</att>
+            <att name="long_name">>20um Concentration Of Chlorophyll In Sea Water</att>
+            <att name="standard_name">concentration_of_chlorophyll_in_sea_water</att>
+            <att name="units">ug/L</att>
+        </addAttributes>
+    </dataVariable>
+    <dataVariable>
+        <sourceName>chla_2um</sourceName>
+        <destinationName>chla_2um</destinationName>
+        <dataType>double</dataType>
+        <!-- sourceAttributes>
+        </sourceAttributes -->
+        <addAttributes>
+            <att name="colorBarMaximum" type="double">30.0</att>
+            <att name="colorBarMinimum" type="double">0</att>
+            <att name="long_name">"2um to 20um Concentration Of Chlorophyll In Sea Water"</att>
+            <att name="standard_name">concentration_of_chlorophyll_in_sea_water</att>
+            <att name="units">ug/L</att>
+        </addAttributes>
+    </dataVariable>
+    <dataVariable>
+        <sourceName>chla_3um</sourceName>
+        <destinationName>chla_3um</destinationName>
+        <dataType>double</dataType>
+        <!-- sourceAttributes>
+        </sourceAttributes -->
+        <addAttributes>
+            <att name="colorBarMaximum" type="double">30.0</att>
+            <att name="colorBarMinimum" type="double">0</att>
+            <att name="long_name">3um to 20um Concentration Of Chlorophyll In Sea Water</att>
+            <att name="standard_name">concentration_of_chlorophyll_in_sea_water</att>
+            <att name="units">ug/L</att>
+        </addAttributes>
+    </dataVariable>
+    <dataVariable>
+        <sourceName>chla_gf_f</sourceName>
+        <destinationName>chla_gf_f</destinationName>
+        <dataType>double</dataType>
+        <!-- sourceAttributes>
+        </sourceAttributes -->
+        <addAttributes>
+            <att name="colorBarMaximum" type="double">30.0</att>
+            <att name="colorBarMinimum" type="double">0</att>
+            <att name="long_name"> Smaller than 3um Concentration Of Chlorophyll In Sea Water</att>
+            <att name="standard_name">concentration_of_chlorophyll_in_sea_water</att>
+            <att name="units">ug/L</att>
+        </addAttributes>
+    </dataVariable>
+    <dataVariable>
+        <sourceName>chla_bulk_gf_f</sourceName>
+        <destinationName>chla_bulk_gf_f</destinationName>
+        <dataType>double</dataType>
+        <!-- sourceAttributes>
+        </sourceAttributes -->
+        <addAttributes>
+            <att name="colorBarMaximum" type="double">30.0</att>
+            <att name="colorBarMinimum" type="double">0</att>
+            <att name="long_name">Bulk Concentration Of Chlorophyll In Sea Water</att>
+            <att name="standard_name">concentration_of_chlorophyll_in_sea_water</att>
+            <att name="units">ug/L</att>
+        </addAttributes>
+    </dataVariable>
+</dataset>

--- a/views/HakaiChlorophyllSampleResearch.sql
+++ b/views/HakaiChlorophyllSampleResearch.sql
@@ -80,7 +80,7 @@ FROM (
                 END
             ) chla_bulk_gf_f
         FROM eims.output_chlorophyll
-        WHERE collected > '2018-09-05'
+        WHERE collected > '2018-05-04'
             AND quality_level in ('Principal Investigator', 'Technicianmr')
             and (
                 chla_flag in ('AV')

--- a/views/HakaiChlorophyllSampleResearch.sql
+++ b/views/HakaiChlorophyllSampleResearch.sql
@@ -15,11 +15,13 @@ SELECT "work_area",
     -- There are a few cases where records have multiple nil
     (array_remove(array_agg(phaeo_20um), Null)) [1]::NUMERIC phaeo_20um,
     (array_remove(array_agg(phaeo_3um), Null)) [1]::NUMERIC phaeo_3um,
+    (array_remove(array_agg(phaeo_2um), Null)) [1]::NUMERIC phaeo_2um,
     (array_remove(array_agg(phaeo_gf_f), Null)) [1]::NUMERIC phaeo_gf_f,
     (array_remove(array_agg(phaeo_bulk_gf_f), Null)) [1]::NUMERIC phaeo_bulk_gf_f,
     -- chla
     (array_remove(array_agg(chla_20um), Null)) [1]::NUMERIC chla_20um,
     (array_remove(array_agg(chla_3um), Null)) [1]::NUMERIC chla_3um,
+    (array_remove(array_agg(chla_2um), Null)) [1]::NUMERIC chla_2um,
     (array_remove(array_agg(chla_gf_f), Null)) [1]::NUMERIC chla_gf_f,
     (array_remove(array_agg(chla_bulk_gf_f), Null)) [1]::NUMERIC chla_bulk_gf_f
 FROM (
@@ -37,8 +39,14 @@ FROM (
             ) phaeo_3um,
             (
                 CASE
+                    WHEN filter_type = '2um' THEN phaeo
+                END
+            ) phaeo_2um,
+            (
+                CASE
                     WHEN filter_type = 'GF/F' THEN phaeo
                 END
+            
             ) phaeo_gf_f,
             (
                 CASE
@@ -56,6 +64,11 @@ FROM (
                     WHEN filter_type = '3um' THEN chla
                 END
             ) chla_3um,
+            (
+                CASE
+                    WHEN filter_type = '2um' THEN chla
+                END
+            ) chla_2um,
             (
                 CASE
                     WHEN filter_type = 'GF/F' THEN chla


### PR DESCRIPTION
2um filter size is missing from pivoted chlorophyll and phao data.