### PR TITLE
Rename variables *(2|3)um_gff to *gff_(2|3)um in research table 

### DIFF
--- a/views/HakaiChlorophyllSampleProvisional.sql
+++ b/views/HakaiChlorophyllSampleProvisional.sql
@@ -1,16 +1,17 @@
 DROP TABLE IF EXISTS erddap."HakaiChlorophyllSampleProvisional";
-CREATE TABLE IF NOT EXISTS erddap."HakaiChlorophyllSampleProvisional" AS
-SELECT 
-*,
-(case when subquery2.chla_3_20um is not null then subquery2.chla_gff else null end) chla_gff_3um,
-(case when subquery2.chla_2_20um is not null then subquery2.chla_gff else null end) chla_gff_2um,
-(case when subquery2.chla_2_20um is not null then subquery2.chla_gff_flag else null end) chla_gff_2um_flag,
-(case when subquery2.chla_3_20um is not null then subquery2.chla_gff_flag else null end) chla_gff_3um_flag,
-(case when subquery2.phaeo_3_20um is not null then subquery2.phaeo_gff else null end) phaeo_gff_3um,
-(case when subquery2.phaeo_2_20um is not null then subquery2.phaeo_gff else null end) phaeo_gff_2um,
-(case when subquery2.phaeo_2_20um is not null then subquery2.phaeo_gff_flag else null end) phaeo_gff_2um_flag,
-(case when subquery2.phaeo_3_20um is not null then subquery2.phaeo_gff_flag else null end) phaeo_gff_3um_flag
- from (
+CREATE TABLE
+IF NOT EXISTS erddap."HakaiChlorophyllSampleProvisional" AS
+SELECT
+    *,
+    (case when subquery2.chla_3_20um is not null then subquery2.chla_gff else null end) chla_gff_3um,
+    (case when subquery2.chla_2_20um is not null then subquery2.chla_gff else null end) chla_gff_2um,
+    (case when subquery2.chla_2_20um is not null then subquery2.chla_gff_flag else null end) chla_gff_2um_flag,
+    (case when subquery2.chla_3_20um is not null then subquery2.chla_gff_flag else null end) chla_gff_3um_flag,
+    (case when subquery2.phaeo_3_20um is not null then subquery2.phaeo_gff else null end) phaeo_gff_3um,
+    (case when subquery2.phaeo_2_20um is not null then subquery2.phaeo_gff else null end) phaeo_gff_2um,
+    (case when subquery2.phaeo_2_20um is not null then subquery2.phaeo_gff_flag else null end) phaeo_gff_2um_flag,
+    (case when subquery2.phaeo_3_20um is not null then subquery2.phaeo_gff_flag else null end) phaeo_gff_3um_flag
+from (
 SELECT "work_area",
     "organization",
     "survey",
@@ -49,123 +50,126 @@ SELECT "work_area",
     (array_remove(array_agg(chla_gff_flag), Null)) [1]::TEXT chla_gff_flag,
     (array_remove(array_agg(chla_bulk_gff_flag), Null)) [1]::TEXT chla_bulk_gff_flag
 
-FROM (
+FROM
+(
         select *,
-            (
-                CASE 
-                    WHEN pressure_transducer_depth IS NULL THEN line_out_depth
-                    ELSE pressure_transducer_depth
-                END
-            ) depth,
-            -- phaeo
-            (
-                CASE
-                    WHEN filter_type = '20um' THEN phaeo
-                END
-            ) phaeo_20um,
-            (
-                CASE
-                    WHEN filter_type = '3um' THEN phaeo
-                END
-            ) phaeo_3_20um,
-            (
-                CASE
-                    WHEN filter_type = '2um' THEN phaeo
-                END
-            ) phaeo_2_20um,
-            (
-                CASE
-                    WHEN filter_type = 'GF/F' THEN phaeo
-                END
-            
-            ) phaeo_gff,
-            (
-                CASE
-                    WHEN filter_type = 'Bulk GF/F' THEN phaeo
-                END
-            ) phaeo_bulk_gff,
-            -- phaeo_flag
-            (
-                CASE
-                    WHEN filter_type = '20um' THEN phaeo_flag
-                END
-            ) phaeo_20um_flag,
-            (
-                CASE
-                    WHEN filter_type = '3um' THEN phaeo_flag
-                END
-            ) phaeo_3_20um_flag,
-            (
-                CASE
-                    WHEN filter_type = '2um' THEN phaeo_flag
-                END
-            ) phaeo_2_20um_flag,
-            (
-                CASE
-                    WHEN filter_type = 'GF/F' THEN phaeo_flag
-                END
-            
-            ) phaeo_gff_flag,
-            (
-                CASE
-                    WHEN filter_type = 'Bulk GF/F' THEN phaeo
-                END
-            ) phaeo_bulk_gff_flag,
-            -- chla
-            (
-                CASE
-                    WHEN filter_type = '20um' THEN chla
-                END
-            ) chla_20um,
-            (
-                CASE
-                    WHEN filter_type = '3um' THEN chla
-                END
-            ) chla_3_20um,
-            (
-                CASE
-                    WHEN filter_type = '2um' THEN chla
-                END
-            ) chla_2_20um,
-            (
-                CASE
-                    WHEN filter_type = 'GF/F' THEN chla
-                END
-            ) chla_gff,
-            (
-                CASE
-                    WHEN filter_type = 'GF/F' THEN chla
-                END
-            ) chla_bulk_gff,
-            -- chla_flag
-            (
-                CASE
-                    WHEN filter_type = '20um' THEN chla_flag
-                END
-            ) chla_20um_flag,
-            (
-                CASE
-                    WHEN filter_type = '3um' THEN chla_flag
-                END
-            ) chla_3_20um_flag,
-            (
-                CASE
-                    WHEN filter_type = '2um' THEN chla_flag
-                END
-            ) chla_2_20um_flag,
-            (
-                CASE
-                    WHEN filter_type = 'GF/F' THEN chla_flag
-                END
-            ) chla_gff_flag,
-            (
-                CASE
-                    WHEN filter_type = 'Bulk GF/F' THEN chla_flag
-                END
-            ) chla_bulk_gff_flag
-        FROM eims.output_chlorophyll
-    ) subquery
-group by (
+    (
+        CASE 
+            WHEN pressure_transducer_depth IS NULL THEN line_out_depth
+            ELSE pressure_transducer_depth
+        END
+    ) depth,
+    -- phaeo
+    (
+        CASE
+            WHEN filter_type = '20um' THEN phaeo
+        END
+    ) phaeo_20um,
+    (
+        CASE
+            WHEN filter_type = '3um' THEN phaeo
+        END
+    ) phaeo_3_20um,
+    (
+        CASE
+            WHEN filter_type = '2um' THEN phaeo
+        END
+    ) phaeo_2_20um,
+    (
+        CASE
+            WHEN filter_type = 'GF/F' THEN phaeo
+        END
+    
+    ) phaeo_gff,
+    (
+        CASE
+            WHEN filter_type = 'Bulk GF/F' THEN phaeo
+        END
+    ) phaeo_bulk_gff,
+    -- phaeo_flag
+    (
+        CASE
+            WHEN filter_type = '20um' THEN phaeo_flag
+        END
+    ) phaeo_20um_flag,
+    (
+        CASE
+            WHEN filter_type = '3um' THEN phaeo_flag
+        END
+    ) phaeo_3_20um_flag,
+    (
+        CASE
+            WHEN filter_type = '2um' THEN phaeo_flag
+        END
+    ) phaeo_2_20um_flag,
+    (
+        CASE
+            WHEN filter_type = 'GF/F' THEN phaeo_flag
+        END
+    
+    ) phaeo_gff_flag,
+    (
+        CASE
+            WHEN filter_type = 'Bulk GF/F' THEN phaeo_flag
+        END
+    ) phaeo_bulk_gff_flag,
+    -- chla
+    (
+        CASE
+            WHEN filter_type = '20um' THEN chla
+        END
+    ) chla_20um,
+    (
+        CASE
+            WHEN filter_type = '3um' THEN chla
+        END
+    ) chla_3_20um,
+    (
+        CASE
+            WHEN filter_type = '2um' THEN chla
+        END
+    ) chla_2_20um,
+    (
+        CASE
+            WHEN filter_type = 'GF/F' THEN chla
+        END
+    ) chla_gff,
+    (
+        CASE
+            WHEN filter_type = 'GF/F' THEN chla
+        END
+    ) chla_bulk_gff,
+    -- chla_flag
+    (
+        CASE
+            WHEN filter_type = '20um' THEN chla_flag
+        END
+    ) chla_20um_flag,
+    (
+        CASE
+            WHEN filter_type = '3um' THEN chla_flag
+        END
+    ) chla_3_20um_flag,
+    (
+        CASE
+            WHEN filter_type = '2um' THEN chla_flag
+        END
+    ) chla_2_20um_flag,
+    (
+        CASE
+            WHEN filter_type = 'GF/F' THEN chla_flag
+        END
+    ) chla_gff_flag,
+    (
+        CASE
+            WHEN filter_type = 'Bulk GF/F' THEN chla_flag
+        END
+    ) chla_bulk_gff_flag
+FROM eims.output_chlorophyll
+    )
+subquery
+group by
+(
         "work_area",
         "organization",
         "survey",

--- a/views/HakaiChlorophyllSampleResearch.sql
+++ b/views/HakaiChlorophyllSampleResearch.sql
@@ -1,12 +1,13 @@
 DROP TABLE IF EXISTS erddap."HakaiChlorophyllSampleResearch";
-CREATE TABLE IF NOT EXISTS erddap."HakaiChlorophyllSampleResearch" AS
-select 
-*,
-(case when subquery2.chla_3_20um is not null then subquery2.chla_gff else null end) chla_3um_gff,
-(case when subquery2.chla_2_20um is not null then subquery2.chla_gff else null end) chla_2um_gff,
-(case when subquery2.phaeo_3_20um is not null then subquery2.phaeo_gff else null end) phaeo_3um_gff,
-(case when subquery2.phaeo_2_20um is not null then subquery2.phaeo_gff else null end) phaeo_2um_gff
- from (
+CREATE TABLE
+IF NOT EXISTS erddap."HakaiChlorophyllSampleResearch" AS
+select
+    *,
+    (case when subquery2.chla_3_20um is not null then subquery2.chla_gff else null end) chla_gff_3um,
+    (case when subquery2.chla_2_20um is not null then subquery2.chla_gff else null end) chla_gff_2um,
+    (case when subquery2.phaeo_3_20um is not null then subquery2.phaeo_gff else null end) phaeo_gff_3um,
+    (case when subquery2.phaeo_2_20um is not null then subquery2.phaeo_gff else null end) phaeo_gff_2um
+from (
 SELECT "work_area",
     "organization",
     "survey",
@@ -32,75 +33,78 @@ SELECT "work_area",
     (array_remove(array_agg(chla_2_20um), Null)) [1]::NUMERIC chla_2_20um,
     (array_remove(array_agg(chla_gff), Null)) [1]::NUMERIC chla_gff,
     (array_remove(array_agg(chla_bulk_gff), Null)) [1]::NUMERIC chla_bulk_gff
-FROM (
-        select *,
-            (
-                CASE 
-                    WHEN pressure_transducer_depth IS NULL THEN line_out_depth
-                    ELSE pressure_transducer_depth
-                END
-            ) depth,
-            -- phaeo
-            (
-                CASE
-                    WHEN filter_type = '20um' THEN phaeo
-                END
-            ) phaeo_20um,
-            (
-                CASE
-                    WHEN filter_type = '3um' THEN phaeo
-                END
-            ) phaeo_3_20um,
-            (
-                CASE
-                    WHEN filter_type = '2um' THEN phaeo
-                END
-            ) phaeo_2_20um,
-            (
-                CASE
-                    WHEN filter_type = 'GF/F' THEN phaeo
-                END
-            ) phaeo_gff,
-            (
-                CASE
-                    WHEN filter_type = 'Bulk GF/F' THEN phaeo
-                END
-            ) phaeo_bulk_gff,
-            -- chla
-            (
-                CASE
-                    WHEN filter_type = '20um' THEN chla
-                END
-            ) chla_20um,
-            (
-                CASE
-                    WHEN filter_type = '3um' THEN chla
-                END
-            ) chla_3_20um,
-            (
-                CASE
-                    WHEN filter_type = '2um' THEN chla
-                END
-            ) chla_2_20um,
-            (
-                CASE
-                    WHEN filter_type = 'GF/F' THEN chla
-                END
-            ) chla_gff,
-            (
-                CASE
-                    WHEN filter_type = 'Bulk GF/F' THEN chla
-                END
-            ) chla_bulk_gff
-        FROM eims.output_chlorophyll
-        WHERE collected > '2018-05-04'
-            AND quality_level in ('Principal Investigator', 'Technicianmr')
-            and (
+FROM
+(
+    select *,
+    (
+        CASE 
+            WHEN pressure_transducer_depth IS NULL THEN line_out_depth
+            ELSE pressure_transducer_depth
+        END
+    ) depth,
+    -- phaeo
+    (
+        CASE
+            WHEN filter_type = '20um' THEN phaeo
+        END
+    ) phaeo_20um,
+    (
+        CASE
+            WHEN filter_type = '3um' THEN phaeo
+        END
+    ) phaeo_3_20um,
+    (
+        CASE
+            WHEN filter_type = '2um' THEN phaeo
+        END
+    ) phaeo_2_20um,
+    (
+        CASE
+            WHEN filter_type = 'GF/F' THEN phaeo
+        END
+    ) phaeo_gff,
+    (
+        CASE
+            WHEN filter_type = 'Bulk GF/F' THEN phaeo
+        END
+    ) phaeo_bulk_gff,
+    -- chla
+    (
+        CASE
+            WHEN filter_type = '20um' THEN chla
+        END
+    ) chla_20um,
+    (
+        CASE
+            WHEN filter_type = '3um' THEN chla
+        END
+    ) chla_3_20um,
+    (
+        CASE
+            WHEN filter_type = '2um' THEN chla
+        END
+    ) chla_2_20um,
+    (
+        CASE
+            WHEN filter_type = 'GF/F' THEN chla
+        END
+    ) chla_gff,
+    (
+        CASE
+            WHEN filter_type = 'Bulk GF/F' THEN chla
+        END
+    ) chla_bulk_gff
+FROM eims.output_chlorophyll
+WHERE collected > '2018-05-04'
+    AND quality_level in ('Principal Investigator', 'Technicianmr')
+    and (
                 chla_flag in ('AV')
-                AND phaeo_flag in ('AV')
+    AND phaeo_flag in ('AV')
             )
-    ) subquery
-group by (
+    )
+subquery
+group by
+(
         "work_area",
         "organization",
         "survey",


### PR DESCRIPTION
Quick fix to the chlorophyll datasets tables. Just spaces to the Provisional but some variable name changes for the research table. ex: `2um_gff `replace by `gff_2um`