### PR TITLE
Fix Bulk GFF matching on provisional chlorophyll table

### DIFF
--- a/views/HakaiChlorophyllSampleProvisional.sql
+++ b/views/HakaiChlorophyllSampleProvisional.sql
@@ -136,7 +136,7 @@ FROM
     ) chla_gff,
     (
         CASE
-            WHEN filter_type = 'GF/F' THEN chla
+            WHEN filter_type = 'Bulk GF/F' THEN chla
         END
     ) chla_bulk_gff,
     -- chla_flag


### PR DESCRIPTION
Quick fix to the chlorophyll datasets tables. Just spaces to the Provisional but some variable name changes for the research table.