### PR TITLE
Add DOI to CTD Research ERDDAP

### DIFF
--- a/datasets/HakaiWaterPropertiesInstrumentProfileResearch.xml
+++ b/datasets/HakaiWaterPropertiesInstrumentProfileResearch.xml
@@ -55,7 +55,7 @@
         <att name="publisher_url">https://www.hakai.org/</att>
         <att name="Conventions">COARDS, CF-1.6, ACDD-1.3</att>
         <att name="institution">Hakai Institute</att>
-        <att name="infoUrl">hakai.org</att>
+        <att name="infoUrl">https://www.doi.org/10.21966/6cz5-6d70</att>
         <att name="sourceUrl">(local files)</att>
         <att name="keywords">aggregate_quality_flag, backscatter, backscatter_beta, backscatter_beta_flag, c_star_at, c_star_at_flag, c_star_at_flag_description, c_star_at_UQL, cast, cdom, cdom_ppb, cdom_ppb_flag,  chlorophyll, chlorophyll-a, conductivity, dissolved, dissolved oxygen, dissolved_oxygen_ml_l, dissolved_oxygen_percent, downwelling_photosynthetic_photon_spherical_irradiance_in_sea_water, flc, mass_concentration_of_chlorophyll_in_sea_water, par,  platform_speed_wrt_sea_water, pressure, rinko, rinko_do_ml_l, sea_water_electrical_conductivity, sea_water_practical_salinity, sea_water_pressure, sea_water_temperature, sea_water_turbidity, spec_cond, temperature,turbidity, volume_beam_attenuation_coefficient_of_radiative_flux_in_sea_water_corrected_for_pure_water_attenuance, volume_fraction_of_oxygen_in_sea_water</att>
         <att name="keywords_vocabulary">GCMD Science Keywords</att>

--- a/datasets/HakaiWaterPropertiesInstrumentProfileResearch.xml
+++ b/datasets/HakaiWaterPropertiesInstrumentProfileResearch.xml
@@ -74,6 +74,9 @@
         <att name="keywords">Calvert Island,Quadra Island,subSurfaceSalinity,coastal zone,PAR,turbidity,fluorescence,salinity,Strait of Georgia,subSurfaceTemperature,Johnstone Strait,Queen Charlotte Sound,oxygen,photosynthetically active radiation,transmissometer</att>
         <att name="summary">Temperature, conductivity, dissolved oxygen, fluorescence, photosynthetic active radiation, and turbidity data collected from 2012 to present by the Hakai Institute in waters surrounding Calvert Island, Johnstone Strait, and Quadra Island areas. This dataset presents data collected by oceanographic profiler instruments (RBR XR-620, RBR Concerto, RBR Maestro, and Seabird SBE 19plus v2) which have been automatically processed by following respective manufacturer's guidelines (see Hakai Water Properties Profile Processing and QA/QC Procedure Manual). The provisional processed data are then quality controlled by applying a series of tests that are following the QARTOD standards and more tests specific to the Hakai Institute data (see Hakai Water Properties Profile Processing and QA/QC Procedure Manual). The research dataset provides a subset of the provisional dataset which has been manually reviewed and judged good for science quality level. Data were collected by the Hakai Institute Oceanography Program, the Nearshore Program, and the Juvenile Salmon Program.</att>
         <att name="title">Hakai Water Properties Vertical Profiles Measured by Oceanographic Profilers, Research</att>
+        <att name="doi">10.21966/6cz5-6d70</att>
+        <att name="id">10.21966/6cz5-6d70</att>
+        <att name="naming_authority">org.doi</att>
     </addAttributes>
     <dataVariable>
         <sourceName>work_area</sourceName>


### PR DESCRIPTION
Add DOI to the research CTD Profile dataset ERDDAP within the global attributes id, naming_authority and infoUrl. #70 