### PR TITLE
Fix QU5 mooring and Pruth moorings

### DIFF
--- a/views/HakaiPruthMooringProvisional.sql
+++ b/views/HakaiPruthMooringProvisional.sql
@@ -1,8 +1,8 @@
-DROP VIEW erddap."HakaiPruthMMooringProvisional"
+DROP VIEW erddap."HakaiPruthMooringProvisional"
 CREATE OR REPLACE VIEW erddap."HakaiPruthMooringProvisional" AS (
 	SELECT 
 		depth,
-		measurement_time,
+		measurement_time AS "measurementTime",
 		water_temp_ql as watertemp_ql,
 		water_temp_qc AS watertemp_qc,
 		water_temp_uql AS watertemp_uql,

--- a/views/HakaiPruthMooringProvisional.sql
+++ b/views/HakaiPruthMooringProvisional.sql
@@ -1,150 +1,28 @@
--- DROP VIEW erddap."HakaiPruthMooringProvisional"
+DROP VIEW erddap."HakaiPruthMMooringProvisional"
 CREATE OR REPLACE VIEW erddap."HakaiPruthMooringProvisional" AS (
-        SELECT t."measurementTime",
-            m.*
-        FROM sn."PruthMooring:5minuteSamples" t
-            CROSS JOIN LATERAL (
-                VALUES (
-                        0,
-                        "PruthMooring:WaterTemp_0m_QL",
-                        "PruthMooring:WaterTemp_0m_QC",
-                        "PruthMooring:WaterTemp_0m_UQL",
-                        "PruthMooring:WaterTemp_0m_Med",
-                        "PruthMooring:WaterTemp_0m_Avg",
-                        "PruthMooring:WaterTemp_0m_Min",
-                        "PruthMooring:WaterTemp_0m_Max",
-                        "PruthMooring:WaterTemp_0m_Std"
-                    ),
-                    (
-                        2,
-                        "PruthMooring:WaterTemp_2m_QL",
-                        "PruthMooring:WaterTemp_2m_QC",
-                        "PruthMooring:WaterTemp_2m_UQL",
-                        "PruthMooring:WaterTemp_2m_Med",
-                        "PruthMooring:WaterTemp_2m_Avg",
-                        "PruthMooring:WaterTemp_2m_Min",
-                        "PruthMooring:WaterTemp_2m_Max",
-                        "PruthMooring:WaterTemp_2m_Std"
-                    ),
-                    (
-                        5,
-                        "PruthMooring:WaterTemp_5m_QL",
-                        "PruthMooring:WaterTemp_5m_QC",
-                        "PruthMooring:WaterTemp_5m_UQL",
-                        "PruthMooring:WaterTemp_5m_Med",
-                        "PruthMooring:WaterTemp_5m_Avg",
-                        "PruthMooring:WaterTemp_5m_Min",
-                        "PruthMooring:WaterTemp_5m_Max",
-                        "PruthMooring:WaterTemp_5m_Std"
-                    ),
-                    (
-                        7.5,
-                        "PruthMooring:WaterTemp_7_5m_QL",
-                        "PruthMooring:WaterTemp_7_5m_QC",
-                        "PruthMooring:WaterTemp_7_5m_UQL",
-                        "PruthMooring:WaterTemp_7_5m_Med",
-                        "PruthMooring:WaterTemp_7_5m_Avg",
-                        "PruthMooring:WaterTemp_7_5m_Min",
-                        "PruthMooring:WaterTemp_7_5m_Max",
-                        "PruthMooring:WaterTemp_7_5m_Std"
-                    ),
-                    (
-                        10,
-                        "PruthMooring:WaterTemp_10m_QL",
-                        "PruthMooring:WaterTemp_10m_QC",
-                        "PruthMooring:WaterTemp_10m_UQL",
-                        "PruthMooring:WaterTemp_10m_Med",
-                        "PruthMooring:WaterTemp_10m_Avg",
-                        "PruthMooring:WaterTemp_10m_Min",
-                        "PruthMooring:WaterTemp_10m_Max",
-                        "PruthMooring:WaterTemp_10m_Std"
-                    ),
-                    (
-                        15,
-                        "PruthMooring:WaterTemp_15m_QL",
-                        "PruthMooring:WaterTemp_15m_QC",
-                        "PruthMooring:WaterTemp_15m_UQL",
-                        "PruthMooring:WaterTemp_15m_Med",
-                        "PruthMooring:WaterTemp_15m_Avg",
-                        "PruthMooring:WaterTemp_15m_Min",
-                        "PruthMooring:WaterTemp_15m_Max",
-                        "PruthMooring:WaterTemp_15m_Std"
-                    ),
-                    (
-                        20,
-                        "PruthMooring:WaterTemp_20m_QL",
-                        "PruthMooring:WaterTemp_20m_QC",
-                        "PruthMooring:WaterTemp_20m_UQL",
-                        "PruthMooring:WaterTemp_20m_Med",
-                        "PruthMooring:WaterTemp_20m_Avg",
-                        "PruthMooring:WaterTemp_20m_Min",
-                        "PruthMooring:WaterTemp_20m_Max",
-                        "PruthMooring:WaterTemp_20m_Std"
-                    ),
-                    (
-                        25,
-                        "PruthMooring:WaterTemp_25m_QL",
-                        "PruthMooring:WaterTemp_25m_QC",
-                        "PruthMooring:WaterTemp_25m_UQL",
-                        "PruthMooring:WaterTemp_25m_Med",
-                        "PruthMooring:WaterTemp_25m_Avg",
-                        "PruthMooring:WaterTemp_25m_Min",
-                        "PruthMooring:WaterTemp_25m_Max",
-                        "PruthMooring:WaterTemp_25m_Std"
-                    ),
-                    (
-                        30,
-                        "PruthMooring:WaterTemp_30m_QL",
-                        "PruthMooring:WaterTemp_30m_QC",
-                        "PruthMooring:WaterTemp_30m_UQL",
-                        "PruthMooring:WaterTemp_30m_Med",
-                        "PruthMooring:WaterTemp_30m_Avg",
-                        "PruthMooring:WaterTemp_30m_Min",
-                        "PruthMooring:WaterTemp_30m_Max",
-                        "PruthMooring:WaterTemp_30m_Std"
-                    ),
-                    (
-                        40,
-                        "PruthMooring:WaterTemp_40m_QL",
-                        "PruthMooring:WaterTemp_40m_QC",
-                        "PruthMooring:WaterTemp_40m_UQL",
-                        "PruthMooring:WaterTemp_40m_Med",
-                        "PruthMooring:WaterTemp_40m_Avg",
-                        "PruthMooring:WaterTemp_40m_Min",
-                        "PruthMooring:WaterTemp_40m_Max",
-                        "PruthMooring:WaterTemp_40m_Std"
-                    ),
-                    (
-                        50,
-                        "PruthMooring:WaterTemp_50m_QL",
-                        "PruthMooring:WaterTemp_50m_QC",
-                        "PruthMooring:WaterTemp_50m_UQL",
-                        "PruthMooring:WaterTemp_50m_Med",
-                        "PruthMooring:WaterTemp_50m_Avg",
-                        "PruthMooring:WaterTemp_50m_Min",
-                        "PruthMooring:WaterTemp_50m_Max",
-                        "PruthMooring:WaterTemp_50m_Std"
-                    ),
-                    (
-                        60,
-                        "PruthMooring:WaterTemp_60m_QL",
-                        "PruthMooring:WaterTemp_60m_QC",
-                        "PruthMooring:WaterTemp_60m_UQL",
-                        "PruthMooring:WaterTemp_60m_Med",
-                        "PruthMooring:WaterTemp_60m_Avg",
-                        "PruthMooring:WaterTemp_60m_Min",
-                        "PruthMooring:WaterTemp_60m_Max",
-                        "PruthMooring:WaterTemp_60m_Std"
-                    )
-            ) AS m(
-                depth,
-                watertemp_ql,
-                watertemp_qc,
-                watertemp_uql,
-                watertemp_med,
-                watertemp_avg,
-                watertemp_min,
-                watertemp_max,
-                watertemp_std
-            )
-    );
+	SELECT 
+		depth,
+		measurement_time,
+		water_temp_ql as watertemp_ql,
+		water_temp_qc AS watertemp_qc,
+		water_temp_uql AS watertemp_uql,
+		water_temp_med AS watertemp_med,
+		water_temp_avg AS watertemp_avg,
+		water_temp_min AS watertemp_min,
+		water_temp_max AS watertemp_max,
+		water_temp_std AS watertemp_std
+	FROM (
+		SELECT 0 AS depth,d0.* FROM sn.pruth_mooring_0m_5minute d0
+		UNION ALL SELECT 2  AS depth,d2.* FROM sn.pruth_mooring_2m_5minute d2
+		UNION ALL SELECT 5  AS depth,d5.* FROM sn.pruth_mooring_5m_5minute d5
+		UNION ALL SELECT 7.5  AS depth,d7.* FROM sn.pruth_mooring_7_5m_5minute d7
+		UNION ALL SELECT 10  AS depth,d10.* FROM sn.pruth_mooring_10m_5minute d10    
+		UNION ALL SELECT 15  AS depth,d15.* FROM sn.pruth_mooring_15m_5minute d15
+		UNION ALL SELECT 20  AS depth,d20.* FROM sn.pruth_mooring_20m_5minute d20
+		UNION ALL SELECT 25  AS depth,d25.* FROM sn.pruth_mooring_25m_5minute d25
+		UNION ALL SELECT 30  AS depth,d30.* FROM sn.pruth_mooring_30m_5minute d30
+		UNION ALL SELECT 40  AS depth,d40.* FROM sn.pruth_mooring_10m_5minute d40
+		UNION ALL SELECT 50  AS depth,d50.* FROM sn.pruth_mooring_50m_5minute d50
+		UNION ALL SELECT 60  AS depth,d60.* FROM sn.pruth_mooring_60m_5minute d60
+	) water 
+ );

--- a/views/HakaiPruthMooringProvisional.sql
+++ b/views/HakaiPruthMooringProvisional.sql
@@ -1,4 +1,4 @@
-DROP VIEW erddap."HakaiPruthMooringProvisional"
+DROP VIEW IF EXISTS erddap."HakaiPruthMooringProvisional";
 CREATE OR REPLACE VIEW erddap."HakaiPruthMooringProvisional" AS (
 	SELECT 
 		depth,

--- a/views/HakaiQU5MMooringProvisional.sql
+++ b/views/HakaiQU5MMooringProvisional.sql
@@ -1,4 +1,4 @@
-DROP VIEW erddap."HakaiQU5MMooringProvisional"
+DROP VIEW IF EXISTS erddap."HakaiQU5MMooringProvisional";
 CREATE OR REPLACE VIEW erddap."HakaiQU5MMooringProvisional" AS (
 	SELECT 
 		COALESCE(water.depth, air.depth) as depth,

--- a/views/HakaiQU5MMooringProvisional.sql
+++ b/views/HakaiQU5MMooringProvisional.sql
@@ -2,7 +2,7 @@ DROP VIEW erddap."HakaiQU5MMooringProvisional"
 CREATE OR REPLACE VIEW erddap."HakaiQU5MMooringProvisional" AS (
 	SELECT 
 		COALESCE(water.depth, air.depth) as depth,
-		COALESCE(water.measurement_time, air.measurement_time) as measurement_time,
+		COALESCE(water.measurement_time, air.measurement_time) as "measurementTime",
 		water.water_temp_ql as watertemp_ql,
 		water.water_temp_qc AS watertemp_qc,
 		water.water_temp_uql AS watertemp_uql,

--- a/views/HakaiQU5MMooringProvisional.sql
+++ b/views/HakaiQU5MMooringProvisional.sql
@@ -1,158 +1,38 @@
--- DROP VIEW erddap."HakaiQU5MMooringProvisional"
+DROP VIEW erddap."HakaiQU5MMooringProvisional"
 CREATE OR REPLACE VIEW erddap."HakaiQU5MMooringProvisional" AS (
-        SELECT t."measurementTime",
-        	t."QU5_Mooring:AirTemp_Avg" as airtemp_avg,
-        	t."QU5_Mooring:AirTemp_Max" as airtemp_max,
-        	t."QU5_Mooring:AirTemp_Med" as airtemp_med,
-        	t."QU5_Mooring:AirTemp_Min" as airtemp_min,
-            t."QU5_Mooring:AirTemp_Std" as airtemp_std,
-        	t."QU5_Mooring:AirTemp_QC"  as airtemp_qc,
-        	t."QU5_Mooring:AirTemp_QL"  as airtemp_ql,
-        	t."QU5_Mooring:AirTemp_UQL" as airtemp_uql,
-            m.*
-        FROM sn."QU5_Mooring:5minuteSamples" t
-            CROSS JOIN LATERAL (
-                VALUES (
-                        0.3,
-                        "QU5_Mooring:WaterTemp_0_3m_QL",
-                        "QU5_Mooring:WaterTemp_0_3m_QC",
-                        "QU5_Mooring:WaterTemp_0_3m_UQL",
-                        "QU5_Mooring:WaterTemp_0_3m_Med",
-                        "QU5_Mooring:WaterTemp_0_3m_Avg",
-                        "QU5_Mooring:WaterTemp_0_3m_Min",
-                        "QU5_Mooring:WaterTemp_0_3m_Max",
-                        "QU5_Mooring:WaterTemp_0_3m_Std"
-                    ),
-                    (
-                        2,
-                        "QU5_Mooring:WaterTemp_2m_QL",
-                        "QU5_Mooring:WaterTemp_2m_QC",
-                        "QU5_Mooring:WaterTemp_2m_UQL",
-                        "QU5_Mooring:WaterTemp_2m_Med",
-                        "QU5_Mooring:WaterTemp_2m_Avg",
-                        "QU5_Mooring:WaterTemp_2m_Min",
-                        "QU5_Mooring:WaterTemp_2m_Max",
-                        "QU5_Mooring:WaterTemp_2m_Std"
-                    ),
-                    (
-                        5,
-                        "QU5_Mooring:WaterTemp_5m_QL",
-                        "QU5_Mooring:WaterTemp_5m_QC",
-                        "QU5_Mooring:WaterTemp_5m_UQL",
-                        "QU5_Mooring:WaterTemp_5m_Med",
-                        "QU5_Mooring:WaterTemp_5m_Avg",
-                        "QU5_Mooring:WaterTemp_5m_Min",
-                        "QU5_Mooring:WaterTemp_5m_Max",
-                        "QU5_Mooring:WaterTemp_5m_Std"
-                    ),
-                    (
-                        7.5,
-                        "QU5_Mooring:WaterTemp_7_5m_QL",
-                        "QU5_Mooring:WaterTemp_7_5m_QC",
-                        "QU5_Mooring:WaterTemp_7_5m_UQL",
-                        "QU5_Mooring:WaterTemp_7_5m_Med",
-                        "QU5_Mooring:WaterTemp_7_5m_Avg",
-                        "QU5_Mooring:WaterTemp_7_5m_Min",
-                        "QU5_Mooring:WaterTemp_7_5m_Max",
-                        "QU5_Mooring:WaterTemp_7_5m_Std"
-                    ),
-                    (
-                        10,
-                        "QU5_Mooring:WaterTemp_10m_QL",
-                        "QU5_Mooring:WaterTemp_10m_QC",
-                        "QU5_Mooring:WaterTemp_10m_UQL",
-                        "QU5_Mooring:WaterTemp_10m_Med",
-                        "QU5_Mooring:WaterTemp_10m_Avg",
-                        "QU5_Mooring:WaterTemp_10m_Min",
-                        "QU5_Mooring:WaterTemp_10m_Max",
-                        "QU5_Mooring:WaterTemp_10m_Std"
-                    ),
-                    (
-                        15,
-                        "QU5_Mooring:WaterTemp_15m_QL",
-                        "QU5_Mooring:WaterTemp_15m_QC",
-                        "QU5_Mooring:WaterTemp_15m_UQL",
-                        "QU5_Mooring:WaterTemp_15m_Med",
-                        "QU5_Mooring:WaterTemp_15m_Avg",
-                        "QU5_Mooring:WaterTemp_15m_Min",
-                        "QU5_Mooring:WaterTemp_15m_Max",
-                        "QU5_Mooring:WaterTemp_15m_Std"
-                    ),
-                    (
-                        20,
-                        "QU5_Mooring:WaterTemp_20m_QL",
-                        "QU5_Mooring:WaterTemp_20m_QC",
-                        "QU5_Mooring:WaterTemp_20m_UQL",
-                        "QU5_Mooring:WaterTemp_20m_Med",
-                        "QU5_Mooring:WaterTemp_20m_Avg",
-                        "QU5_Mooring:WaterTemp_20m_Min",
-                        "QU5_Mooring:WaterTemp_20m_Max",
-                        "QU5_Mooring:WaterTemp_20m_Std"
-                    ),
-                    (
-                        25,
-                        "QU5_Mooring:WaterTemp_25m_QL",
-                        "QU5_Mooring:WaterTemp_25m_QC",
-                        "QU5_Mooring:WaterTemp_25m_UQL",
-                        "QU5_Mooring:WaterTemp_25m_Med",
-                        "QU5_Mooring:WaterTemp_25m_Avg",
-                        "QU5_Mooring:WaterTemp_25m_Min",
-                        "QU5_Mooring:WaterTemp_25m_Max",
-                        "QU5_Mooring:WaterTemp_25m_Std"
-                    ),
-                    (
-                        30,
-                        "QU5_Mooring:WaterTemp_30m_QL",
-                        "QU5_Mooring:WaterTemp_30m_QC",
-                        "QU5_Mooring:WaterTemp_30m_UQL",
-                        "QU5_Mooring:WaterTemp_30m_Med",
-                        "QU5_Mooring:WaterTemp_30m_Avg",
-                        "QU5_Mooring:WaterTemp_30m_Min",
-                        "QU5_Mooring:WaterTemp_30m_Max",
-                        "QU5_Mooring:WaterTemp_30m_Std"
-                    ),
-                    (
-                        40,
-                        "QU5_Mooring:WaterTemp_40m_QL",
-                        "QU5_Mooring:WaterTemp_40m_QC",
-                        "QU5_Mooring:WaterTemp_40m_UQL",
-                        "QU5_Mooring:WaterTemp_40m_Med",
-                        "QU5_Mooring:WaterTemp_40m_Avg",
-                        "QU5_Mooring:WaterTemp_40m_Min",
-                        "QU5_Mooring:WaterTemp_40m_Max",
-                        "QU5_Mooring:WaterTemp_40m_Std"
-                    ),
-                    (
-                        50,
-                        "QU5_Mooring:WaterTemp_50m_QL",
-                        "QU5_Mooring:WaterTemp_50m_QC",
-                        "QU5_Mooring:WaterTemp_50m_UQL",
-                        "QU5_Mooring:WaterTemp_50m_Med",
-                        "QU5_Mooring:WaterTemp_50m_Avg",
-                        "QU5_Mooring:WaterTemp_50m_Min",
-                        "QU5_Mooring:WaterTemp_50m_Max",
-                        "QU5_Mooring:WaterTemp_50m_Std"
-                    ),
-                    (
-                        60,
-                        "QU5_Mooring:WaterTemp_60m_QL",
-                        "QU5_Mooring:WaterTemp_60m_QC",
-                        "QU5_Mooring:WaterTemp_60m_UQL",
-                        "QU5_Mooring:WaterTemp_60m_Med",
-                        "QU5_Mooring:WaterTemp_60m_Avg",
-                        "QU5_Mooring:WaterTemp_60m_Min",
-                        "QU5_Mooring:WaterTemp_60m_Max",
-                        "QU5_Mooring:WaterTemp_60m_Std"
-                    )
-            ) AS m(
-                depth,
-                watertemp_ql,
-                watertemp_qc,
-                watertemp_uql,
-                watertemp_med,
-                watertemp_avg,
-                watertemp_min,
-                watertemp_max,
-                watertemp_std
-            )
-    );
+	SELECT 
+		COALESCE(water.depth, air.depth) as depth,
+		COALESCE(water.measurement_time, air.measurement_time) as measurement_time,
+		water.water_temp_ql as watertemp_ql,
+		water.water_temp_qc AS watertemp_qc,
+		water.water_temp_uql AS watertemp_uql,
+		water.water_temp_med AS watertemp_med,
+		water.water_temp_avg AS watertemp_avg,
+		water.water_temp_min AS watertemp_min,
+		water.water_temp_max AS watertemp_max,
+		water.water_temp_std AS watertemp_std,
+		air.air_temp_ql AS airtemp_ql,
+		air.air_temp_qc AS airtemp_qc,
+		air.air_temp_uql AS airtemp_uql,
+		air.air_temp_med AS airtemp_med,
+		air.air_temp_avg AS airtemp_avg,
+		air.air_temp_min AS airtemp_min,
+		air.air_temp_max AS airtemp_max,
+		air.air_temp_std AS airtemp_std
+	FROM (
+	SELECT 0.3 AS depth,d0.* FROM sn.qu5_mooring_0_3m_5minute d0
+	UNION ALL SELECT 2  AS depth,d2.* FROM sn.qu5_mooring_2m_5minute d2
+	UNION ALL SELECT 5  AS depth,d5.* FROM sn.qu5_mooring_5m_5minute d5
+	UNION ALL SELECT 7.5  AS depth,d7.* FROM sn.qu5_mooring_7_5m_5minute d7
+	UNION ALL SELECT 10  AS depth,d10.* FROM sn.qu5_mooring_10m_5minute d10    
+	UNION ALL SELECT 15  AS depth,d15.* FROM sn.qu5_mooring_15m_5minute d15
+	UNION ALL SELECT 20  AS depth,d20.* FROM sn.qu5_mooring_20m_5minute d20
+	UNION ALL SELECT 25  AS depth,d25.* FROM sn.qu5_mooring_25m_5minute d25
+	UNION ALL SELECT 30  AS depth,d30.* FROM sn.qu5_mooring_30m_5minute d30
+	UNION ALL SELECT 40  AS depth,d40.* FROM sn.qu5_mooring_10m_5minute d40
+	UNION ALL SELECT 50  AS depth,d50.* FROM sn.qu5_mooring_50m_5minute d50
+	UNION ALL SELECT 60  AS depth,d60.* FROM sn.qu5_mooring_60m_5minute d60) water 
+	FULL OUTER JOIN
+ 	(SELECT -0.5  AS depth,measurement_time,air_temp_ql,air_temp_qc,air_temp_uql,air_temp_med,air_temp_avg,air_temp_min,air_temp_max,air_temp_std FROM sn.qu5_mooring_air_5minute air) air 
+ 	ON water.DEPTH=air.DEPTH AND water.measurement_time=air.measurement_time
+ );


### PR DESCRIPTION
Those two query changes applies to the QU5 and Pruth mooring views within the erddap schema. Those changes are already in production and successfully worked