### PR TITLE
Make PruthDock dataset pull from the erddap schema view

### DIFF
--- a/datasets/HakaiPruthDockProvisional.xml
+++ b/datasets/HakaiPruthDockProvisional.xml
@@ -2,7 +2,7 @@
     <sourceUrl>hakai_erddap_sourceUrl</sourceUrl>
     <driverName>org.postgresql.Driver</driverName>
     <schemaName>erddap</schemaName>
-    <tableName>"PruthDock:5minuteSamples"</tableName>
+    <tableName>"HakaiPruthDockProvisional"</tableName>
     <reloadEveryNMinutes>10080</reloadEveryNMinutes>
     <!-- sourceAttributes>
     </sourceAttributes -->

--- a/datasets/HakaiPruthDockProvisional.xml
+++ b/datasets/HakaiPruthDockProvisional.xml
@@ -1,7 +1,7 @@
 <dataset type="EDDTableFromDatabase" datasetID="HakaiPruthDockProvisional" active="true">
     <sourceUrl>hakai_erddap_sourceUrl</sourceUrl>
     <driverName>org.postgresql.Driver</driverName>
-    <schemaName>sn</schemaName>
+    <schemaName>erddap</schemaName>
     <tableName>"PruthDock:5minuteSamples"</tableName>
     <reloadEveryNMinutes>10080</reloadEveryNMinutes>
     <!-- sourceAttributes>


### PR DESCRIPTION
The `HakaiPruthDockProvisional` datasets have been failing on the production server for some time. This dataset was pulling data from the `sn` schema while all the other datasets are pulling from the `erddap` schema. 

I wonder if this has to do with maybe some potentially new changes to the driver use to connect erddap to the database `org.postgresql.Driver`. It could also be related to the latest version of ERDDAP. 

The same dataset is working on the development server while still pulling from the `sn` schema. That being said, the development erddap is still running on ERDDAP 2.02.

I will try to run the server locally with a different erddap version
- [x] Run locally on ERDDAP 2.18 to sn."PruthDock:5minuteSamples"
- [x] Run locally on ERDDAP 2.18 to erddap.HakaiPruthDockProvisional
