### PR TITLE
replace erddap  schemas tables by views

### DIFF
--- a/views/HakaiCTDProvisional.sql
+++ b/views/HakaiCTDProvisional.sql
@@ -1,5 +1,5 @@
 CREATE
-OR REPLACE TABLE erddap."HakaiCTDProvisional" AS
+OR REPLACE VIEW erddap."HakaiCTDProvisional" AS
 SELECT
     d.measurement_dt AS "measurementTime",
     d.ctd_cast_pk,

--- a/views/HakaiChlorophyllSampleProvisional.sql
+++ b/views/HakaiChlorophyllSampleProvisional.sql
@@ -1,5 +1,5 @@
 CREATE
-OR REPLACE TABLE IF NOT EXISTS erddap."HakaiChlorophyllSampleProvisional" AS
+OR REPLACE VIEW erddap."HakaiChlorophyllSampleProvisional" AS
 SELECT
     *,
     (

--- a/views/HakaiChlorophyllSampleResearch.sql
+++ b/views/HakaiChlorophyllSampleResearch.sql
@@ -1,5 +1,5 @@
 CREATE
-OR REPLACE TABLE IF NOT EXISTS erddap."HakaiChlorophyllSampleResearch" AS
+OR REPLACE VIEW erddap."HakaiChlorophyllSampleResearch" AS
 select
     *,
     (

--- a/views/HakaiNutrientSampleResearch.sql
+++ b/views/HakaiNutrientSampleResearch.sql
@@ -1,5 +1,5 @@
 CREATE
-OR REPLACE TABLE erddap."HakaiNutrientSampleResearch" AS
+OR REPLACE VIEW erddap."HakaiNutrientSampleResearch" AS
 SELECT
     action,
     event_pk,


### PR DESCRIPTION
The original configuration replaced yesterday was generating TABLES. 

This present will generate VIEWS of the similar result. 

Questions related:
1. Do we need to drop the already existing Tables as available on hakai db?
2. Any idea how this will affect the response time of a query to those tables?