### PR TITLE
drop empty depth rows from research dataset

### DIFF
--- a/views/HakaiWaterPropertiesInstrumentProfileResearch.sql
+++ b/views/HakaiWaterPropertiesInstrumentProfileResearch.sql
@@ -12,6 +12,7 @@ WHERE
     )
     AND d.status IS NULL
     AND d.measurement_dt IS NOT NULL
+    and d.depth is null
     AND d.direction_flag :: text = 'd' :: text
     AND d.work_area in ('CALVERT', 'QUADRA', 'JOHNSTONE STRAIT')
     AND d.cruise NOT IN ('CEDAR COAST', 'HER')


### PR DESCRIPTION
Hakai CTD research is now outputing all the not qced and flagged data as empty rows. We'll remove any data which has now depth associated, which will get rid of that.