### PR TITLE
Update algae explorer configs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ temp.tar
 .pguser
 .pgdb
 .pghost
+.idea/

--- a/datasets.d/sentinel_3A_POLYMER.xml
+++ b/datasets.d/sentinel_3A_POLYMER.xml
@@ -1,5 +1,5 @@
 <dataset type="EDDGridFromNcFiles" datasetID="sentinel_3A_POLYMER" active="true">
-    <reloadEveryNMinutes>10080</reloadEveryNMinutes>
+    <reloadEveryNMinutes>1440</reloadEveryNMinutes>
     <updateEveryNMillis>10000</updateEveryNMillis>
     <fileDir>/algae_explorer/5_erddap_data</fileDir>
     <fileNameRegex>polymer_mosaic_output\.nc</fileNameRegex>

--- a/datasets.d/sentinel_3A_POLYMER.xml
+++ b/datasets.d/sentinel_3A_POLYMER.xml
@@ -7,7 +7,7 @@
     <pathRegex>.*</pathRegex>
     <metadataFrom>last</metadataFrom>
     <matchAxisNDigits>10</matchAxisNDigits>
-    <fileTableInMemory>false</fileTableInMemory>
+    <fileTableInMemory>true</fileTableInMemory>
     <accessibleViaWMS>true</accessibleViaWMS>
     <!-- sourceAttributes>
         <att name="Conventions">CF-1.4</att>

--- a/datasets.d/sentinel_3A_POLYMER_8Day.xml
+++ b/datasets.d/sentinel_3A_POLYMER_8Day.xml
@@ -1,5 +1,5 @@
 <dataset type="EDDGridFromNcFiles" datasetID="sentinel_3A_POLYMER_8Day" active="true">
-    <reloadEveryNMinutes>10080</reloadEveryNMinutes>
+    <reloadEveryNMinutes>1440</reloadEveryNMinutes>
     <updateEveryNMillis>10000</updateEveryNMillis>
     <fileDir>/algae_explorer/6_bin8_data/</fileDir>
     <fileNameRegex>.*\.nc</fileNameRegex>

--- a/datasets.d/sentinel_3A_POLYMER_8Day.xml
+++ b/datasets.d/sentinel_3A_POLYMER_8Day.xml
@@ -7,7 +7,7 @@
     <pathRegex>.*</pathRegex>
     <metadataFrom>last</metadataFrom>
     <matchAxisNDigits>10</matchAxisNDigits>
-    <fileTableInMemory>false</fileTableInMemory>
+    <fileTableInMemory>true</fileTableInMemory>
     <accessibleViaWMS>true</accessibleViaWMS>
     <defaultGraphQuery>chl_conc_mean[last][0][0:last][0:last]&amp;.draw=surface&amp;.vars=longitude|latitude|temp</defaultGraphQuery>
     <!-- sourceAttributes>

--- a/docker-compose-local.yml
+++ b/docker-compose-local.yml
@@ -16,7 +16,7 @@ services:
       - "./erddap/data:/erddapData"
       - "${DATASETS_DIR:-./datasets}:/datasets"
       - "./init.d:/init.d"
-      # - "/mnt/efs/algex:/algae_explorer"
+      # - "/mnt/s3/algex:/algae_explorer"
       - "./datasets.d:/datasets.d"
     healthcheck:
       test:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@ services:
       resources:
         limits:
           memory: 12G
-      replicas: 1      
+      replicas: 1
     volumes:
       - "./erddap/EDDTableFromDatabase.java:/usr/local/tomcat/webapps/erddap/WEB-INF/classes/gov/noaa/pfel/erddap/datasetEDDTableFromDatabase.java"
       - "./erddap/conf/robots.txt:/usr/local/tomcat/webapps/ROOT/robots.txt"
@@ -22,7 +22,7 @@ services:
       - "./erddap/data:/erddapData"
       - "${DATASETS_DIR:-./datasets}:/datasets"
       - "./init.d:/init.d"
-      - "/mnt/efs/algex:/algae_explorer"
+      - "/mnt/s3/algex:/algae_explorer"
       - "./datasets.d:/datasets.d"
       - "./logs:/usr/local/tomcat/logs"
     healthcheck:


### PR DESCRIPTION
Closes #300 

Updates the mount location for algae explorer data to a more idiomatic location given that the files are now loaded via s3-files instead of the old EFS location.

Also improves the data reload mechanism should the processing pipeline fail to refresh the dataset properly (i.e. refresh runs on a daily instead of the previously weekly interval).

Finally, changes the config to keep the algae explorer data table in JVM memory rather than requiring a full directory walk on each request. RAM usage should be pretty small (~3MB) and significantly speed up data request times for apps like algaeexplorer.ca